### PR TITLE
Erreur pour react-native-fast-image@^5.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "react-native-android-fullscreen-webview-video": "^1.0.3",
     "react-native-app-link": "^1.0.0",
     "react-native-device-info": "^0.26.2",
-    "react-native-fast-image": "^5.1.1",
+    "react-native-fast-image": "5.2.0",
     "react-native-fence-html": "1.0.6",
     "react-native-firebase": "^5.2.1",
     "react-native-fit-image": "1.5.4",


### PR DESCRIPTION
A partir de la v5.2.1, react-native-fast-image nécessite react@^16.8.3. 
Sans mettre à jour React, on obtient une erreur `(0 , _react.memo) is not a function` au runtime.

J'ai donc fixé la version du paquet à 5.2.0 en attendant.