### PR TITLE
fix(i18n): IMPULS-5795, system language sync on automatic mode

### DIFF
--- a/src/app/i18n.ts
+++ b/src/app/i18n.ts
@@ -127,21 +127,33 @@ export namespace I18n {
     return i18n.language as I18n.SupportedLocales;
   }
 
+  export async function getExpectedLanguage() {
+    const storedLang = await OldStorageFunctions.getItemJson(I18N_APP_LANG);
+
+    //dertnimes if language is manually set or system language is used
+    if (!isEmpty(storedLang)) {
+      return storedLang as string;
+    }
+
+    const locales = RNLocalize.getLocales();
+
+    const firstSupportedLocale = locales.find(locale => supportedLanguages.includes(locale.languageCode as I18n.SupportedLocales));
+
+    const lang = firstSupportedLocale?.languageCode ?? fallbackLng;
+
+    return lang;
+  }
+
   // Set language to device one
   export async function setLanguage() {
-    const bestAvailableLanguage = RNLocalize.findBestLanguageTag(supportedLanguages) as {
-      languageTag: string;
-      isRTL: boolean;
-    };
-    const lang = await OldStorageFunctions.getItemJson(I18N_APP_LANG);
-    if (isEmpty(lang)) {
-      const newLang = bestAvailableLanguage?.languageTag ?? fallbackLng;
-      i18n.language = newLang;
-    } else {
-      i18n.language = (lang as string) ?? fallbackLng;
-    }
-    moment.locale(momentLocales[i18n.language?.split('-')[0]] ?? momentLocales.default);
-    return i18n.language as I18n.SupportedLocales;
+    // Get expected language (either stored or system one)
+    const newLang = await getExpectedLanguage();
+
+    i18n.language = newLang;
+
+    moment.locale(momentLocales[newLang.split('-')[0]] ?? momentLocales.default);
+
+    return newLang;
   }
 
   export const changeLanguage = async (lang: SupportedLocales | 'auto') => {
@@ -151,6 +163,15 @@ export namespace I18n {
     RNRestart.restart();
   };
 
+  export async function refreshLanguageIfChanged() {
+    const currentLang = i18n.language;
+
+    const expectedLang = await getExpectedLanguage();
+
+    if (currentLang !== expectedLang) {
+      RNRestart.restart();
+    }
+  }
   // Toggle i18n Keys (dev && alpha only)
   // Toggle button available in UserHomeScreen (src/framework/modules/user/screens/home/screen.tsx)
   export const toggleShowKeys = async () => {

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -7,7 +7,6 @@ import inAppMessaging from '@react-native-firebase/in-app-messaging';
 import DeviceInfo from 'react-native-device-info';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { KeyboardProvider } from 'react-native-keyboard-controller';
-import * as RNLocalize from 'react-native-localize';
 import { initialWindowMetrics, SafeAreaProvider } from 'react-native-safe-area-context';
 import * as Redux from 'react-redux';
 import { Action, Store } from 'redux';
@@ -16,7 +15,7 @@ import { AppStartupHandler } from '~/app/startup';
 import { UI_STYLES } from '~/framework/components/constants';
 import { useConstructor } from '~/framework/hooks/constructor';
 import appConf from '~/framework/util/appConf';
-import { isEmpty } from '~/framework/util/object';
+import { NetworkMonitorProvider } from '~/framework/util/monitoring/network';
 import { Storage } from '~/framework/util/storage';
 import { Trackers } from '~/framework/util/tracker';
 import { ZendeskProvider } from '~/framework/util/zendesk';
@@ -25,28 +24,17 @@ import { DeviceTrust } from './device-trust';
 import { I18n } from './i18n';
 import { ModuleCompat } from './module/compat';
 import configureStore from './store';
-import { NetworkMonitorProvider } from '~/framework/util/monitoring/network';
 
 function useAppState() {
-  const [currentLocale, setCurrentLocale] = React.useState(I18n.getLanguage());
   const currentState = React.useRef<AppStateStatus>(AppState.currentState);
 
-  const handleAppStateChange = React.useCallback(
-    (nextAppState: AppStateStatus) => {
-      currentState.current = nextAppState;
-      if (nextAppState === 'active') {
-        // Track foreground state
-        Trackers.trackDebugEvent('Application', 'DISPLAY');
-        // Change locale if needed
-        const locales = RNLocalize.getLocales();
-        const newLocale = isEmpty(locales) ? null : locales[0].languageCode;
-        I18n.setLanguage().then(lng => {
-          if (newLocale !== currentLocale) setCurrentLocale(lng as I18n.SupportedLocales);
-        });
-      }
-    },
-    [currentLocale],
-  );
+  const handleAppStateChange = React.useCallback((nextAppState: AppStateStatus) => {
+    currentState.current = nextAppState;
+
+    if (nextAppState === 'active') {
+      I18n.refreshLanguageIfChanged();
+    }
+  }, []);
 
   React.useEffect(() => {
     const appStateListener = AppState.addEventListener('change', handleAppStateChange);

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -32,6 +32,8 @@ function useAppState() {
     currentState.current = nextAppState;
 
     if (nextAppState === 'active') {
+      // Track foreground state
+      Trackers.trackDebugEvent('Application', 'DISPLAY');
       I18n.refreshLanguageIfChanged();
     }
   }, []);


### PR DESCRIPTION
i18n and restart logic moved in `i18n.ts`
this merge uses getLocales to get the ordered(by priority) system list, iterate through it to find the first match containted in the apps supported languages.

`findBestLanguageTag` would not stop at the first match it encountered.